### PR TITLE
Allow building on systems w/o strl funcs (like glibc) by using libbsd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('hopalong', 'c',
 
 add_project_arguments('-DWLR_USE_UNSTABLE', language: 'c')
 
+cc = meson.get_compiler('c')
 
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
@@ -19,6 +20,12 @@ glesv2	       = dependency('glesv2')
 wlroots        = dependency('wlroots')
 xkbcommon      = dependency('xkbcommon')
 
+# glibc lacks strl*. if we can't detect them, assume we need libbsd
+lacking_libc = false
+if cc.has_function('strlcpy') == false or cc.has_function('strlcat') == false
+  lacking_libc = true
+  bsd_overlay = dependency('libbsd-overlay')
+endif
 
 if get_option('xwayland')
 	xcb    = dependency('xcb', required: true)

--- a/src/compositor/meson.build
+++ b/src/compositor/meson.build
@@ -14,18 +14,23 @@ hopalong_sources = [
   'hopalong-main.c',
 ]
 
+hopalong_dependencies = [
+  server_protos,
+  wayland_server,
+  cairo,
+  pangocairo,
+  pixman,
+  glesv2,
+  wlroots,
+  xkbcommon
+]
+
+if lacking_libc
+  hopalong_dependencies += bsd_overlay
+endif
 
 hopalong_exe = executable('hopalong',
   hopalong_sources,
-  dependencies: [
-    server_protos,
-    wayland_server,
-    cairo,
-    pangocairo,
-    pixman,
-    glesv2,
-    wlroots,
-    xkbcommon
-  ],
+  dependencies: hopalong_dependencies,
   install: true
 )


### PR DESCRIPTION
This should be pulled in as a dependency only if required functions
are missing from the system. Otherwise, this should be inert.