### PR TITLE
Fix segfault when opening window from another VT

### DIFF
--- a/src/compositor/hopalong-view.c
+++ b/src/compositor/hopalong-view.c
@@ -361,7 +361,7 @@ hopalong_view_focus(struct hopalong_view *view, struct wlr_surface *surface)
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
 
 	surface = hopalong_view_get_surface(view);
-	if (surface != NULL)
+	if (surface != NULL && keyboard != NULL)
 		wlr_seat_keyboard_notify_enter(seat, surface,
 			keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
 


### PR DESCRIPTION
This fixes a segfault that occurs when switching to a different VT from Hopalong and attempting to open a window from it. This pull request fixes issue #7 