### PR TITLE
Don't generate a title texture if it's empty

### DIFF
--- a/src/compositor/hopalong-view.c
+++ b/src/compositor/hopalong-view.c
@@ -164,8 +164,15 @@ hopalong_view_generate_title_texture(struct hopalong_output *output, struct hopa
 	const char *title_data = hopalong_view_getprop(view, HOPALONG_VIEW_TITLE);
 	if (title_data == NULL)
 		title_data = hopalong_view_getprop(view, HOPALONG_VIEW_APP_ID);
-	if (title_data != NULL)
-		strlcpy(title, title_data, sizeof title);
+
+	/* Fix for gedit dialog's empty title which causes an assertion failure */
+	if (title_data == NULL || title_data[0] == '\0')
+	{
+		view->title_dirty = false;
+		return false;
+	}
+
+	strlcpy(title, title_data, sizeof title);
 
 	float scale = output->wlr_output->scale;
 	int w = 400;


### PR DESCRIPTION
gedit has an empty title for the unsaved changes dialog, which causes an assertion failure and a crash because of 0 width/ height (so skip texture generation if that's the case)

Fixes #6 (?)

All reported bugs should be fixed now :eyes: